### PR TITLE
add initial fivenorth config

### DIFF
--- a/configs/DevNet/approved-sv-id-values.yaml
+++ b/configs/DevNet/approved-sv-id-values.yaml
@@ -44,3 +44,6 @@ approvedSvIdentities:
   - name: C7-Technology-Services-Limited
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEVAJEEaXnB+CU+rV5QS4I0eNH14YBXHmrl2ubLzOu7vhez3orP1MDmGSD3gLiP9oxi1XiI+D/JcNohAxlm/DDpw==
     rewardWeightBps: 100000
+  - name: Five-North-1
+    publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEVSqn1J3YWij1KBWVNKKOQ8aEPeUc9SFe418mneRdV/PJOX4awAePDrG7A09SYkqP8dyg8ESMw5ltV0dJt5eqlQ==
+    rewardWeightBps: 0


### PR DESCRIPTION
This PR setup the initial configuration with weight to 0 for FiveNorth SV on devnet.

Our domain mapping will be 

```
sv.sv-1.dev.global.canton.network.fivenorth.io
scan.sv-1.dev.global.canton.network.fivenorth.io
wallet.sv-1.dev.global.canton.network.fivenorth.io 
```