### PR TITLE
scripts: Add script to check access to scans

### DIFF
--- a/scripts/check-access-to-scans.sh
+++ b/scripts/check-access-to-scans.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+scan_url="https://scan.sv-2.global.canton.network.digitalasset.com" # DA SV-2 gets allow list applied daily
+
+scans_info_url="$scan_url/api/scan/v0/scans"
+dso_url="$scan_url/api/scan/v0/dso"
+
+curl_timeout=5
+curl_cmd=(curl -sS -m "$curl_timeout")
+
+scan_info=$(
+  echo "Getting data from $scans_info_url ..." >&2
+
+  "${curl_cmd[@]}" "$scans_info_url"
+)
+
+dso=$(
+  echo "Fetching current configuration from $dso_url ..." >&2
+
+  "${curl_cmd[@]}" "$dso_url"
+)
+
+
+svs_all=$(echo "$dso" | jq '[.dso_rules.contract.payload.svs[][1].name]')
+svs_count=$(jq <<< "$svs_all" length)
+svs_from_scan=$(echo "$scan_info" | jq '[.scans[].scans[] | .svName]')
+svs_missing=$(echo "$svs_all" "$svs_from_scan" | jq -s '.[0] - .[1]')
+
+IFS=$'\n' read -r -d '' -a scan_svnames_and_urls < <(
+  echo "$scan_info" |
+    jq -r '[.scans[].scans[] | [.svName, .publicUrl + "/api/scan/version"]] | sort[] | join(" ")' && printf '\0'
+)
+
+echo
+
+scan_data=$(
+  for svname_and_url in "${scan_svnames_and_urls[@]}"; do
+    read svname url <<< "$svname_and_url";
+
+    echo "Trying to access $svname_and_url" >&2
+
+    ("${curl_cmd[@]}" -f "$url" || echo '{"inaccessible": true}') |
+      jq --arg svname "$svname" --arg url "$url" '
+        .svname = $svname |
+        .url = $url
+      '
+    echo
+  done
+)
+
+echo
+
+echo "$scan_data" |
+  jq -sr '
+    ["svName", "url", "version", "commit_ts"],
+    (.[] | [.svname, .url, .version // -1, .commit_ts // -1])
+    | @tsv
+  ' | column -ts$'\t'
+
+svs_inaccessible_count=$(jq -nr <<< "$scan_data" '[inputs | select(.inaccessible)] | length')
+
+echo
+echo "Registered: ${#scan_svnames_and_urls[@]} / Expected: $svs_count"
+echo "Missing: $(jq -r <<< "$svs_missing" 'if length > 0 then join(", ") else "none" end')"
+echo "Inaccessible: $svs_inaccessible_count of $svs_count"


### PR DESCRIPTION
Add check-access-to-scans.sh

Output example:

    Getting data from https://scan.sv-2.global.canton.network.digitalasset.com/api/scan/v0/scans ...
    Fetching current configuration from https://scan.sv-2.global.canton.network.digitalasset.com/api/scan/v0/dso ...

    svName                          url                                                                        version  commit_ts
    C7-Technology-Services-Limited  https://scan.sv-1.global.canton.network.c7.digital/api/scan/version        -1       -1
    Cumberland-1                    https://scan.sv-1.global.canton.network.cumberland.io/api/scan/version     -1       -1
    Cumberland-2                    https://scan.sv-2.global.canton.network.cumberland.io/api/scan/version     -1       -1
    Digital-Asset-1                 https://scan.sv-1.global.canton.network.digitalasset.com/api/scan/version  -1       -1
    Digital-Asset-2                 https://scan.sv-2.global.canton.network.digitalasset.com/api/scan/version  0.3.9    2025-01-30T09:55:30Z
    Global-Synchronizer-Foundation  https://scan.sv-1.global.canton.network.sync.global/api/scan/version       0.3.9    2025-01-30T09:55:30Z
    MPC-Holding-Inc                 https://scan.sv-1.global.canton.network.mpch.io/api/scan/version           -1       -1
    Orb-1-LP-1                      https://scan.sv-1.global.canton.network.orb1lp.mpch.io/api/scan/version    -1       -1
    SV-Nodeops-Limited              https://scan.sv.global.canton.network.sv-nodeops.com/api/scan/version      0.3.9    2025-01-30T09:55:30Z
    Tradeweb-Markets-1              https://scan.sv-1.global.canton.network.tradeweb.com/api/scan/version      -1       -1

    Registered: 10 / Expected: 10
    Missing: none
    Inaccessible: 7 of 10