### PR TITLE
Stas/actions pull request updates and fixes

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,10 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - '**.json'
-      - '**.yaml'
-      - '**.yml'
 
 permissions: {}
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -31,6 +31,7 @@ jobs:
         uses: GrantBirki/json-yaml-validate@e42e6ece9b97f2b220274c909a9a98e380c2c9fd  # v3.2.1
         with:
           base_dir: configs
+          use_gitignore: false
 
       - name: Make sure total sum of reward weights doesn't change unless explicitly allowed
         run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0  # Default is 1. We set it as 0 to get access to the target branch
 
       - name: Validate JSON and YAML files
-        uses: GrantBirki/json-yaml-validate@d7814b94473939c1daaca2c96131b891d4703a3c  # v2.7.1
+        uses: GrantBirki/json-yaml-validate@e42e6ece9b97f2b220274c909a9a98e380c2c9fd  # v3.2.1
         with:
           base_dir: configs
 


### PR DESCRIPTION
- actions, pull request: Remove path filtering
  Filtering by path is not compatible with required status checks
- actions, pull_request: Bump json-yaml-validate version from 2.7.1 to 3.2.1
- actions, pull_request: Disable use_gitignore for json-yaml-validate
  This gets rid of warning "error reading .gitignore file: Error: ENOENT: no such file or directory, open '.gitignore'"