### PR TITLE
diff-reward-weights.sh: Improve output and error handling

### DIFF
--- a/scripts/diff-reward-weights.sh
+++ b/scripts/diff-reward-weights.sh
@@ -37,7 +37,12 @@ config_diff() {
   diff_errors=()
 
   local dso_response; dso_response=$(
-    "${CURL_CMD[@]}" -w '%{header_json}' "$dso_url"
+    # "${CURL_CMD[@]}" -w '%{header_json}' "$dso_url"  # NOTE: header_json is supported by curl >= 7.83.0, below is a workaround for older versions
+    local response; response=$("${CURL_CMD[@]}" -i "$dso_url") || exit 1
+    local response_body; response_body=$(echo "$response" | sed '0,/^\r*$/d')
+    local response_header; response_header=$(echo "$response" | sed '/^\r*$/,$d')
+    local header_last_modified; header_last_modified=$(echo "$response_header" | grep '^last-modified:' | sed 's/^last-modified: //' | jq -nR '{"last-modified": [inputs]}')
+    echo "$response_body$header_last_modified"
   ) || { echo "ERROR: Unable to fetch DSO from $dso_url" >&2; return 1; }
 
   [[ $(echo "$dso_response" | jq -s length) -eq 2 ]] ||


### PR DESCRIPTION
- Run curl once per URL and not twice
- Exit early (on the first error)
- Show "modified X seconds ago" if "last-modified" header is available