### PR TITLE
actions, pull_request: Check reward weight correctly on outdated branch

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -62,5 +62,5 @@ jobs:
 
           exit "$exit_code"
         env:
-          SOURCE_BRANCH: ${{ github.event.pull_request.head.sha }}
+          SOURCE_BRANCH: ${{ github.sha }}
           TARGET_BRANCH: "origin/${{ github.base_ref }}"


### PR DESCRIPTION
- Compare PR branch with merged main against main instead of comparing original PR branch with main to get predictable results when PR branch is stale

This change fixed cases like [this one](https://github.com/global-synchronizer-foundation/configs/actions/runs/14982886448) where total reward weight hasn't changed but the check resulted in failure