### PR TITLE
Temporarily disabling Slack notifications for weight diffs

### DIFF
--- a/.github/workflows/daily_checks.yml
+++ b/.github/workflows/daily_checks.yml
@@ -39,7 +39,8 @@ jobs:
           exit "$exit_code"
 
       - name: Post text to a Slack channel
-        if: failure()
+        #if: failure()
+        if: false  # Temporarily disabled until a proper process to handle the diff is established
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d  # v2.0.0
         with:
           method: chat.postMessage


### PR DESCRIPTION
This is disabled until a proper process to handle the diff is established