### PR TITLE
chore[testnet]: CIP-0032 Update MPCH SV weight to reflect hosted Lukk…

### DIFF
--- a/configs/TestNet/approved-sv-id-values.yaml
+++ b/configs/TestNet/approved-sv-id-values.yaml
@@ -46,7 +46,7 @@ approvedSvIdentities:
         weight: "10000"
   - name: MPC-Holding-Inc
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEOxCYWSBB4hDz7O1XxJ3xswKXxJcQqsgyzBTbWjkwa+ILYXy8T2vtVMoZ+tC/Ykdp3MyFwcMIP1kzcDKCSp0qow==
-    rewardWeightBps: 10000
+    rewardWeightBps: 20000
     extraBeneficiaries:
       - beneficiary: "auth0_007c66f44bc7589a682afe95a21d::12208fdbf6156f607c104512ce12fcb382ce3ec3116e7aa5ddb02b7fce237efd4843" # MPCH
         weight: "10000"


### PR DESCRIPTION
Updates MPCH SV weight with hosted Lukka SV weight

https://lists.sync.global/g/supervalidator-announce/topic/mpch_sv_to_host_lukka_sv/114168418

Expires At:     2025-07-24 12:00 (in 7 days) (UTC+1)
Effective At:  2025-07-25 12:00 (in 8 days) (UTC+1) 