### PR TITLE
actions, pull_request: Fix base_ref for merge queues

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -65,4 +65,4 @@ jobs:
           exit "$exit_code"
         env:
           SOURCE_BRANCH: ${{ github.sha }}
-          TARGET_BRANCH: "origin/${{ github.base_ref }}"
+          TARGET_BRANCH: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_ref || format('origin/{0}', github.base_ref) }}


### PR DESCRIPTION
`github.base_ref` is not available for merge queues so we have to use `github.event.merge_group.base_ref` instead