### PR TITLE
chore: update extraBeneficiaries for GSF on TestNet

### DIFF
--- a/configs/TestNet/approved-sv-id-values.yaml
+++ b/configs/TestNet/approved-sv-id-values.yaml
@@ -30,7 +30,7 @@ approvedSvIdentities:
         weight: 10000
       - beneficiary: "copper-testnetValidator-1::1220030d943f303ae8703182bc73014a62107f46086098ae89353cd969f35a1ecb31" # Copper Clearloop CIP-0039
         weight: 10000
-      - beneficiary: "ObsidianSystems-validator-1::12200a97a3589a8fd95940922a6103363081ec4e73504e536353563cff8138aec0a0" # Obsidian Systems CIP-0037 # "lastCollectedInRound": 18930
+      - beneficiary: "ObsidianSystems-validator-1::12200a97a3589a8fd95940922a6103363081ec4e73504e536353563cff8138aec0a0" # Obsidian Systems CIP-0037
         weight: 10000
       - beneficiary: "circle-validator-1::1220b37c0a6fc08a8364fc3cedcd211044cc73d4eb68f0e5cdab12004fb7812ee453" # Circle CIP-0041
         weight: 100000

--- a/configs/TestNet/approved-sv-id-values.yaml
+++ b/configs/TestNet/approved-sv-id-values.yaml
@@ -19,33 +19,33 @@ approvedSvIdentities:
     rewardWeightBps: 505000
     extraBeneficiaries:
       - beneficiary: "GSF-validator-1::1220cff733e3a29f50b3104f573d51461e85cd685b28dafa684c40813975e6e2ce3d"
-        weight: "100000"
+        weight: 100000
       - beneficiary: "Broadridge-validator-1::1220c89a73e7b47f16dfb48a521eeedfe2a8620ea1b19b815ab427388d9f5427faa5"
-        weight: "100000"
+        weight: 100000
       - beneficiary: "thetie-validator-0::1220e81793d395d56922d4e31e248480a7be6fe1b96082107bf56f4ce0b11b3f0e7d" # The Tie
-        weight: "10000"
+        weight: 10000
       - beneficiary: "copper-testnetValidator-1::1220030d943f303ae8703182bc73014a62107f46086098ae89353cd969f35a1ecb31" # Copper
-        weight: "10000"
+        weight: 10000
       - beneficiary: "DFNS-validator-1::1220b916c84570d2b3d3d4692a8d905ba410f4da4c6cc9578ca9284dfa64235e8a2d" # Dfns
-        weight: "10000"
+        weight: 10000
       - beneficiary: "copper-testnetValidator-1::1220030d943f303ae8703182bc73014a62107f46086098ae89353cd969f35a1ecb31" # Copper Clearloop CIP-0039
-        weight: "10000"
-      - beneficiary: "ObsidianSystems-validator-1::1220932286cab2eefd313d308dfe049905cd2968becdefd78c49176991b87f2d1017" # Obsidian Systems CIP-0037
-        weight: "10000"
+        weight: 10000
+      - beneficiary: "ObsidianSystems-validator-1::12200a97a3589a8fd95940922a6103363081ec4e73504e536353563cff8138aec0a0" # Obsidian Systems CIP-0037 # "lastCollectedInRound": 18930
+        weight: 10000
       - beneficiary: "circle-validator-1::1220b37c0a6fc08a8364fc3cedcd211044cc73d4eb68f0e5cdab12004fb7812ee453" # Circle CIP-0041
-        weight: "100000"
+        weight: 100000
       - beneficiary: "bitwave-testnet-2::1220f85d0de84a8c2de9052f45c15b3729081b09e324686ee32114a2bf7e9727c388" # Bitwave CIP-0055
-        weight: "10000"
-      - beneficiary: "IntellectEU-ghost-1::12202b7cd3b3da8b3449b075e54b0b3de4a437f56f9b179b35a6050d75c866e4bbf0" # IntellectEU CIP-0058
-        weight: "10000"
-      - beneficiary: "AngelHack-ghost-1::12202b7cd3b3da8b3449b075e54b0b3de4a437f56f9b179b35a6050d75c866e4bbf0" # AngelHack CIP-0053
-        weight: "25000"
-      - beneficiary: "Kaiko-ghost-1::12202b7cd3b3da8b3449b075e54b0b3de4a437f56f9b179b35a6050d75c866e4bbf0" # Kaiko CIP-0063
-        weight: "65000"
+        weight: 10000
+      - beneficiary: "IntellectEU-ghost-1::12202b7cd3b3da8b3449b075e54b0b3de4a437f56f9b179b35a6050d75c866e4bbf0" # IntellectEU CIP-0058 # escrow party_id added to the GhostSV-validator-1
+        weight: 10000
+      - beneficiary: "AngelHack-ghost-1::12202b7cd3b3da8b3449b075e54b0b3de4a437f56f9b179b35a6050d75c866e4bbf0" # AngelHack CIP-0053 # escrow party_id added to the GhostSV-validator-1
+        weight: 25000
+      - beneficiary: "Kaiko-ghost-1::12202b7cd3b3da8b3449b075e54b0b3de4a437f56f9b179b35a6050d75c866e4bbf0" # Kaiko CIP-0063 # escrow party_id added to the GhostSV-validator-1
+        weight: 65000
       - beneficiary: "kiln-testnetValidator-1::1220cd771ebde43c6a4a34969354f3201c5eb1be2f69af9c1deedcd9a6a990c1bfa6" # Kiln CIP-0036
-        weight: "10000"
+        weight: 10000
       - beneficiary: "figment-testnet-validator-1::1220483d71e2147a1e3309608821b0e6f53e6a274b96869204bf11812d313773d097" # Figment CIP-0054
-        weight: "10000"
+        weight: 10000
   - name: MPC-Holding-Inc
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEOxCYWSBB4hDz7O1XxJ3xswKXxJcQqsgyzBTbWjkwa+ILYXy8T2vtVMoZ+tC/Ykdp3MyFwcMIP1kzcDKCSp0qow==
     rewardWeightBps: 10000


### PR DESCRIPTION
We need to synchronize this with the real configuration used for the GSF DevNet node.
Updating weights to comply with changes introduced in [0.4.5](https://docs.sync.global/release_notes.html#id-0-4-5)