### PR TITLE
CIP-0058 Update IntellectEU weight for completed milestones

### DIFF
--- a/configs/MainNet/approved-sv-id-values.yaml
+++ b/configs/MainNet/approved-sv-id-values.yaml
@@ -27,7 +27,7 @@ approvedSvIdentities:
         weight: 10000
       - beneficiary: "bitwave-finance-1::1220ab03fc0c7f77428d8f568276b64a6e6a04e340c842581a0d4e676ad7e094c1bb" # Bitwave CIP-0055
         weight: 10000
-      - beneficiary: "IntellectEU-ghost-1::1220f5cf298f609f538b46a2a0347d299028ddca7ea008aaed65e0ca862db974c5e2" # IntellectEU CIP-0058 # escrow party_id added to the GhostSV-validator-1
+      - beneficiary: "IntellectEU-SVrewards-1::122085181345795b9e58122cef90b8df61ddfe128cdaf9abbcb77f8cef92950c1d05" # IntellectEU CIP-0058 # active party_id used to receive an earned weight for completed milestone(s)
         weight: 10000
       - beneficiary: "AngelHack-ghost-1::1220f5cf298f609f538b46a2a0347d299028ddca7ea008aaed65e0ca862db974c5e2" # AngelHack CIP-0053 # escrow party_id added to the GhostSV-validator-1
         weight: 15000

--- a/configs/TestNet/approved-sv-id-values.yaml
+++ b/configs/TestNet/approved-sv-id-values.yaml
@@ -36,7 +36,7 @@ approvedSvIdentities:
         weight: 100000
       - beneficiary: "bitwave-testnet-2::1220f85d0de84a8c2de9052f45c15b3729081b09e324686ee32114a2bf7e9727c388" # Bitwave CIP-0055
         weight: 10000
-      - beneficiary: "IntellectEU-ghost-1::12202b7cd3b3da8b3449b075e54b0b3de4a437f56f9b179b35a6050d75c866e4bbf0" # IntellectEU CIP-0058 # escrow party_id added to the GhostSV-validator-1
+      - beneficiary: "IntellectEU-SVrewards-1::12200845f349239c218b93cc39374aee18db8e876f63f85469cc71aa07d821d34936" # IntellectEU CIP-0058 # active party_id used to receive an earned weight for completed milestone(s)
         weight: 10000
       - beneficiary: "AngelHack-ghost-1::12202b7cd3b3da8b3449b075e54b0b3de4a437f56f9b179b35a6050d75c866e4bbf0" # AngelHack CIP-0053 # escrow party_id added to the GhostSV-validator-1
         weight: 25000


### PR DESCRIPTION
According to [this announcement](https://lists.sync.global/g/cip-announce/message/41), IntellectEU has completed its milestones.

As outlined in the [CIP-0058 "SV Rewards Mechanics" block](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0058/cip-0058.md#mechanics), GSF updates the extraBeneficiary to IntellectEU's separate party, on a separate Validator from the ghost SV validator, to mint its weight 1 rewards from the point of approval forward.
As the full weight is now assigned to a new party, the escrow party ID is removed from the `extraBeneficiaries` configuration (replaced by the "real" party ID).

This change occurred in the actual configuration of the GSF SV node on August 1, 2025, at 23:00 UTC.