### PR TITLE
CIPs-0052-0059-0060 Add Zero Hash, Woodside AI, and Monstera FZE weights to the GSF SV node on MainNet

### DIFF
--- a/configs/MainNet/approved-sv-id-values.yaml
+++ b/configs/MainNet/approved-sv-id-values.yaml
@@ -1,7 +1,7 @@
 approvedSvIdentities:
   - name: Global-Synchronizer-Foundation
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEmWLDU/xZzCtl6prd15Dyi+2/zMtSbHpQh8wJ/R3J9YKDVNpkJVo+qBkmYYSdlAifLz1aymUKqZlWDBvtQCJIaA==
-    rewardWeightBps: 735000
+    rewardWeightBps: 755000
     extraBeneficiaries:
       - beneficiary: "validator_GSF-1::12201725270d497ab23ceffd0d2acce46cc9da44586fd494786ef53cc58b6e4abd79"
         weight: 100000
@@ -44,7 +44,7 @@ approvedSvIdentities:
       - beneficiary: "TRM-validator-1::1220bc3dc0350c7c2479ff1e7dfc67f4af0ee25c9ab63861d953483d9bdbb36691fe" # TRM CIP-0043
         weight: 25000
       - beneficiary: "MonsteraFZE-ghost-1::1220f5cf298f609f538b46a2a0347d299028ddca7ea008aaed65e0ca862db974c5e2" # Monstera FZE CIP-0052 # escrow party_id added to the GhostSV-validator-1
-        weight: 30000
+        weight: 50000
       - beneficiary: "WoodsideAI-ghost-1::1220f5cf298f609f538b46a2a0347d299028ddca7ea008aaed65e0ca862db974c5e2" # Woodside AI CIP-0059 # escrow party_id added to the GhostSV-validator-1
         weight: 100000
       - beneficiary: "ZeroHash-ghost-1::1220f5cf298f609f538b46a2a0347d299028ddca7ea008aaed65e0ca862db974c5e2" # Zero Hash CIP-0060 # escrow party_id added to the GhostSV-validator-1


### PR DESCRIPTION
[Supervalidator-Announce](https://lists.sync.global/g/supervalidator-announce/topic/vote_proposal_to_host_sv/114583070)
 
The vote expires on 2025-08-14 13:00 UTC
The vote becomes effective on 2025-08-15 13:00 UTC