### PR TITLE
Revert "CIP-0043 Add TRM weight to the GSF SV node on DevNet [allow-total-rew…"

### DIFF
--- a/configs/DevNet/approved-sv-id-values.yaml
+++ b/configs/DevNet/approved-sv-id-values.yaml
@@ -28,7 +28,7 @@ approvedSvIdentities:
     rewardWeightBps: 159250
   - name: Global-Synchronizer-Foundation
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE+2XaCekgPDPoEzXeo3yYf6Y+3zbIXKMoR2WYl/pa8CMuOloMXHUfdi6viBJcvoLij7ti5PaqLp1PHJ5tWLteVQ==
-    rewardWeightBps: 530000
+    rewardWeightBps: 505000
     extraBeneficiaries:
       - beneficiary: "GSF-validator-1::12203b389175d5d9a67a443078b3867fb179fc730d5dfb6aca3c509c37e926a6e24b" # GSF-1
         weight: 100000


### PR DESCRIPTION
Reverts global-synchronizer-foundation/configs#159

As the DevNet vote didn't reach a quorum, we need to wait longer before merging this. Unfortunately, I didn't notice that earlier.

Probably, we also need to adjust our alerts to Slack to check who didn't vote yet, 1 day before the expiration date instead of 1 day before the effective date. As if there is no quorum (e.g., 10/17 votes), it will automatically expire at the expiration date, and the remaining 7 SVs will not get a notification about that.