### PR TITLE
DevNet: Add new SV ID key for Digital-Asset-1 and set its weight to 0

### DIFF
--- a/configs/DevNet/approved-sv-id-values.yaml
+++ b/configs/DevNet/approved-sv-id-values.yaml
@@ -21,8 +21,8 @@ approvedSvIdentities:
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1eb+JkH2QFRCZedO/P5cq5d2+yfdwP+jE+9w3cT6BqfHxCd/PyA0mmWMePovShmf97HlUajFuN05kZgxvjcPQw==
     rewardWeightBps: 1_0000
   - name: Digital-Asset-1
-    publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5ZIIu7ciMWwgNmciMq8SfgY6eVi1o8feUEztydSg4cn8bF2mcd59XF7zbXRoxNKpLW2gNz6gnv8Ldfn5MkHPbA==
-    rewardWeightBps: 15_9250
+    publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEXAlWLI4yRTqjHRbFma3KwWUpBxl+TVkvwxJDO298IV3jBeZmMZ/rSedBI1zn3BoWnhRirIUNd9gjjN1LCdY1VQ==
+    rewardWeightBps: 0
   - name: Digital-Asset-2
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEigGf2Onr2vc4jP3uFJ+ZVelkd/V2f07cwQRjrRS+AICooKg3OMFEzkFgZZjbyWJT9vUZte3y8iAXNIMwBNPw6g==
     rewardWeightBps: 15_9250


### PR DESCRIPTION
Preparation for reonboarding Digital-Asset-1 under new (DA-internal) ownership.

Context: https://lists.sync.global/g/supervalidator-announce/topic/fyi_planned_digital_asset/115330544

We'll add the missing DA weight to DA-2 once the governance vote for that has become effective.

Merging this means that we'll be out of sync with the on-ledger state. But:

- The conflict is temporary and we plan to resolve it once ledger voting catches up.
- This change reduces the total weight of DA; so the only party that can be harmed by it is DA (and we're in favor)

Alternatives to this approach would shift our timelines for reonboarding DA-1 significantly.