### PR TITLE
CIPs-0061-0065-0069-0077 Add Chainlink, Layer Zero, Wormhole, Ledger, and Taurus weights to the GSF SV node on TestNet

### DIFF
--- a/configs/TestNet/approved-sv-id-values.yaml
+++ b/configs/TestNet/approved-sv-id-values.yaml
@@ -16,7 +16,7 @@ approvedSvIdentities:
     rewardWeightBps: 13_6125
   - name: Global-Synchronizer-Foundation
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETri1wBeoV3AYnEF/slvViz9GO2g2lcxUQ3SadBTA70Kn87KzAZ/25n6+hhuRebuuGlm70KFKGJGr8RFd1YjB1Q==
-    rewardWeightBps: 81_5000
+    rewardWeightBps: 113_0000
     extraBeneficiaries:
       - beneficiary: "GSF-validator-1::1220cff733e3a29f50b3104f573d51461e85cd685b28dafa684c40813975e6e2ce3d"
         weight: 10_0000
@@ -56,6 +56,18 @@ approvedSvIdentities:
         weight: 5_0000
       - beneficiary: "Hypernative-ghost-1::12202b7cd3b3da8b3449b075e54b0b3de4a437f56f9b179b35a6050d75c866e4bbf0" # Hypernative CIP-0076 # escrow party_id added to the GhostSV-validator-1
         weight: 1_0000
+      - beneficiary: "Chainlink-ghost-1::12202b7cd3b3da8b3449b075e54b0b3de4a437f56f9b179b35a6050d75c866e4bbf0" # Chainlink CIP-0061 # escrow party_id added to the GhostSV-validator-1
+        weight: 7_5000
+      - beneficiary: "Chainlink-ghost-2::12202b7cd3b3da8b3449b075e54b0b3de4a437f56f9b179b35a6050d75c866e4bbf0" # Chainlink CIP-0065 # escrow party_id added to the GhostSV-validator-1
+        weight: 3_0000
+      - beneficiary: "LayerZero-ghost-1::12202b7cd3b3da8b3449b075e54b0b3de4a437f56f9b179b35a6050d75c866e4bbf0" # Layer Zero CIP-0065 # escrow party_id added to the GhostSV-validator-1
+        weight: 3_0000
+      - beneficiary: "Wormhole-ghost-1::12202b7cd3b3da8b3449b075e54b0b3de4a437f56f9b179b35a6050d75c866e4bbf0" # Wormhole CIP-0065 # escrow party_id added to the GhostSV-validator-1
+        weight: 3_0000
+      - beneficiary: "Ledger-ghost-1::12202b7cd3b3da8b3449b075e54b0b3de4a437f56f9b179b35a6050d75c866e4bbf0" # Ledger CIP-0069 # escrow party_id added to the GhostSV-validator-1
+        weight: 5_0000
+      - beneficiary: "Taurus-ghost-1::12202b7cd3b3da8b3449b075e54b0b3de4a437f56f9b179b35a6050d75c866e4bbf0" # Taurus CIP-0077 # escrow party_id added to the GhostSV-validator-1
+        weight: 5_0000
   - name: MPC-Holding-Inc
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEOxCYWSBB4hDz7O1XxJ3xswKXxJcQqsgyzBTbWjkwa+ILYXy8T2vtVMoZ+tC/Ykdp3MyFwcMIP1kzcDKCSp0qow==
     rewardWeightBps: 2_0000


### PR DESCRIPTION
[TBD]

Note that as of the date of submitting this PR, one more party ID for CIP0065-BonusPool (with a weight of 5) is missing. We'll update the list of parties after we agree on the correct naming for it.