### PR TITLE
DevNet: sync approved-sv-id-values with ledger state

### DIFF
--- a/configs/DevNet/approved-sv-id-values.yaml
+++ b/configs/DevNet/approved-sv-id-values.yaml
@@ -25,7 +25,7 @@ approvedSvIdentities:
     rewardWeightBps: 0
   - name: Digital-Asset-2
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEigGf2Onr2vc4jP3uFJ+ZVelkd/V2f07cwQRjrRS+AICooKg3OMFEzkFgZZjbyWJT9vUZte3y8iAXNIMwBNPw6g==
-    rewardWeightBps: 15_9250
+    rewardWeightBps: 21_1500
   - name: Global-Synchronizer-Foundation
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE+2XaCekgPDPoEzXeo3yYf6Y+3zbIXKMoR2WYl/pa8CMuOloMXHUfdi6viBJcvoLij7ti5PaqLp1PHJ5tWLteVQ==
     rewardWeightBps: 81_5000


### PR DESCRIPTION
Following weights shift from DA-1 to DA-2 to prepare for DA-1 reonboarding.

Note that the current total weight for DA is wrong atm due to an operator error. Fixing/avoiding that would have delayed our timeline for reonboarding DA-1, so we decided to ignore. This PR now just syncs up to the current state on ledger.

[allow-total-reward-weight-change]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
