### PR TITLE
TestNet: prepare for DA-1 reonboarding

### DIFF
--- a/configs/TestNet/approved-sv-id-values.yaml
+++ b/configs/TestNet/approved-sv-id-values.yaml
@@ -3,11 +3,11 @@ approvedSvIdentities:
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETM+CeyHvphl9RiPDKL3vVX7F+Qo4fIhJopmgU5B7IzkwSdFic20hFB6tnAuCTU+UBjqZgh8N/h9r+CTrXMPsRg==
     rewardWeightBps: 10_2500
   - name: Digital-Asset-1
-    publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsRRntNkOLF2Wh7JxV0rBQPgT+SendIjFLXKUXCrLbVHqomkypHQiZP8OgFMSlByOnr81fqiUt3G36LUpg/fmgA==
-    rewardWeightBps: 15_9250
+    publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvy3k9wxyJTf57jcSfoRyrQm7bJnWtUyzXTqDTUMyFuLbO4LdfB+IMLZbKDr85ApjjTHGEeKQc/GUM/mGnBBaCw==
+    rewardWeightBps: 0
   - name: Digital-Asset-2
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPKz6BujCKqA6ACviIybPw8aYTsKOYkWN6spIWL4CTxiH26QCyrrYFH06OGxa8UykyPM0yuywDXKF3ZVpWyF0hw==
-    rewardWeightBps: 15_9250
+    rewardWeightBps: 31_8500
   - name: Cumberland-1
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEE0FEwOWZIsogzxbfkFDvg6iVR2P8zmzCwemylXF9/hxynlJOPo4vg3W9AS7y50X5qqj9yrWvVeT9iC1dDMIE0g==
     rewardWeightBps: 13_6125


### PR DESCRIPTION
- shift weights from DA-1 to DA-2 (expected ledger state as of 2025-10-01 08:00 UTC)
- use new public key for DA-1

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
