### PR TITLE
DevNet: remove `Digital-Asset-Eng-` SVs from approved list

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -47,9 +47,6 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
           exit "$exit_code"
-        env:
-          SV_IDS_EXCLUDE: |
-            MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsRRntNkOLF2Wh7JxV0rBQPgT+SendIjFLXKUXCrLbVHqomkypHQiZP8OgFMSlByOnr81fqiUt3G36LUpg/fmgA==  # TODO: Remove this when one of DevNet/Digital-Asset-Eng-2 or TestNet/Digital-Asset-1 gets a new ID
 
       - name: Make sure total sum of reward weights doesn't change unless explicitly allowed
         run: |

--- a/configs/DevNet/approved-sv-id-values.yaml
+++ b/configs/DevNet/approved-sv-id-values.yaml
@@ -8,15 +8,6 @@ approvedSvIdentities:
   - name: Cumberland-2
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE9/PUF/FFmdhbJNtxt+fR67LEW9vM/NluHSKTecvaqx7EYymDRsJf0GShphXwJAgrFzEOQ0Vsmbu6dmO6N1x8/g==
     rewardWeightBps: 13_6125
-  - name: Digital-Asset-Eng-2
-    publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsRRntNkOLF2Wh7JxV0rBQPgT+SendIjFLXKUXCrLbVHqomkypHQiZP8OgFMSlByOnr81fqiUt3G36LUpg/fmgA==
-    rewardWeightBps: 14_0000
-  - name: Digital-Asset-Eng-3
-    publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE0fnbBQiM7UiSNaV6tjPq5lK2buIx5L5nzUuhYWxBk341nFChcbK9pDEO4O6gdxexb/OQP6RhQkDOTDdTCr77CA==
-    rewardWeightBps: 0
-  - name: Digital-Asset-Eng-4
-    publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEa76d2OWmkpCQ2dTWsWyhofV3tOGdlkhoCnPpY7BbQhCb0s3laR1vp57JYu/d5Cf+332PF2XrgjC0yBWUqM4syQ==
-    rewardWeightBps: 0
   - name: DA-Helm-Test-Node
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1eb+JkH2QFRCZedO/P5cq5d2+yfdwP+jE+9w3cT6BqfHxCd/PyA0mmWMePovShmf97HlUajFuN05kZgxvjcPQw==
     rewardWeightBps: 1_0000


### PR DESCRIPTION
We offboarded them without replacement.

Not updating the dso rules snapshot in here - my understanding is that there is a separate sync process for that?

[allow-total-reward-weight-change]

Signed-off-by: Martin Florian <martin.florian@digitalasset.com>
