### PR TITLE
CIP-0063 earned weight increase for the completed milestone (as per T…

### DIFF
--- a/configs/MainNet/approved-sv-id-values.yaml
+++ b/configs/MainNet/approved-sv-id-values.yaml
@@ -34,9 +34,9 @@ approvedSvIdentities:
       - beneficiary: "angelhack-mainnet-1::12205162445638c3f71c9942b74360134b4ebc953b5bea2c25adc99bff130bffd060" # AngelHack CIP-0053 # active party_id used to receive an earned weight for completed milestone(s)
         weight: 1_0000
       - beneficiary: "Kaiko-ghost-1::1220f5cf298f609f538b46a2a0347d299028ddca7ea008aaed65e0ca862db974c5e2" # Kaiko CIP-0063 # escrow party_id added to the GhostSV-validator-1
-        weight: 3_0000
+        weight: 2_5000
       - beneficiary: "kaiko-mainnet-1::1220f67b4f1c8742d83ac7e12749d98195bf88ff120b2dab369291cf6a2ca27be9a9" # Kaiko CIP-0063 # active party_id used to receive an earned weight for completed milestone(s)
-        weight: 3_5000
+        weight: 4_0000
       - beneficiary: "kiln-validator-1::12209024881cf76bf1c15342e9e3b4bd751d5582947a58b42a6532eef867f83ceea3" # Kiln CIP-0036
         weight: 1_0000
       - beneficiary: "figment-mainnetValidator-1::1220b46e6ce64f99510274b4aaa573b32089e69cfee0f1e918539f19f78e9ea23ba4" # Figment CIP-0054


### PR DESCRIPTION
According to [this announcement](https://lists.sync.global/g/tokenomics-announce/message/240), Kaiko has met the milestone for [Enabling strategic adopters to the Canton Network via data products "0.5 per third party using Kaiko applications (capped at 2.5)"](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0063/cip-0063.md#deliverables-for-full-sv-reward) ([details](https://lists.sync.global/g/accountability/topic/kaiko_sv_milestones/115392212), [application announcement](https://www.linkedin.com/posts/qcp-group_proud-to-partner-with-kaiko-and-five-north-activity-7376866064934055936-r2L1/))

Following [CIP-0063 "SV Rewards Mechanics" block](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0063/cip-0063.md#sv-reward-mechanics), GSF adds weight for completed milestones to Kaiko's separate party, on a separate Validator from the ghost SV validator, to mint its weight 0.5 rewards from the point of approval forward. Given the https://github.com/global-synchronizer-foundation/configs/pull/171, the new total earnable weight is 40000 basis points (1.0 + 2.5 + 0.5 = 4).

Kaiko will still have a separate escrow party assigned to the ghost SV Validator with an updated weight of 25000 basis points (3 - 0.5 = 2.5)

This change occurred in the actual configuration of the GSF SV node on October 2, 2025, at 18:45 UTC.