### PR TITLE
CIP-0086 Add ChainSafe weights to the 5N SV node on DevNet

### DIFF
--- a/configs/DevNet/approved-sv-id-values.yaml
+++ b/configs/DevNet/approved-sv-id-values.yaml
@@ -132,12 +132,14 @@ approvedSvIdentities:
     rewardWeightBps: 10_5750
   - name: Five-North-1
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEVSqn1J3YWij1KBWVNKKOQ8aEPeUc9SFe418mneRdV/PJOX4awAePDrG7A09SYkqP8dyg8ESMw5ltV0dJt5eqlQ==
-    rewardWeightBps: 14_0500
+    rewardWeightBps: 16_0500
     extraBeneficiaries:
       - beneficiary: "bsv-ghost-1::122021b2533a670a0eefc3a68e998ef77f56c0b2dc1ef2f40a8f829122079847931b" # Bosphorus SV (BSV)  CIP-0093 # escrow party_id hosted on 5nghost-devnet-2
         weight: 6_0000
       - beneficiary: "qcp-ghost-1::122021b2533a670a0eefc3a68e998ef77f56c0b2dc1ef2f40a8f829122079847931b" # QCP Group SV (QCP)  CIP-0106 # escrow party_id hosted on 5nghost-devnet-2
         weight: 5_0000
+      - beneficiary: "chainsafe-ghost-1::122021b2533a670a0eefc3a68e998ef77f56c0b2dc1ef2f40a8f829122079847931b" # ChainSafe  CIP-0086 # escrow party_id hosted on 5nghost-devnet-2
+        weight: 2_0000
   - name: Proof-Group-1
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEeSP06KmTXsRJ65JGYwtzKRX9gosW+Gf4IwIquPGT8+XM1ey9La4wdZ+eELNZMPGacQ9fDe2JPFuRJE+fdVsfOQ==
     rewardWeightBps: 1_2500


### PR DESCRIPTION
PER CIP-0086

- https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0086/cip-0086.md
- https://lists.sync.global/g/tokenomics-announce/message/295

ChainSafe SV has a max weight of 2 and will be hosted on an escrow validator.

5N reward weight is increased by 2_0000 bps and the extra 2_0000 bps are attributed to the party
chainsafe-ghost-1::122021b2533a670a0eefc3a68e998ef77f56c0b2dc1ef2f40a8f829122079847931b

This party is hosted on 5nghost-devnet-2 validator with disabled wallet and reward minting.