### PR TITLE
CIP-0086 Add ChainSafe weights to the 5N SV node on TestNet

### DIFF
--- a/configs/TestNet/approved-sv-id-values.yaml
+++ b/configs/TestNet/approved-sv-id-values.yaml
@@ -128,12 +128,14 @@ approvedSvIdentities:
     rewardWeightBps: 10_5750
   - name: Five-North-1
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJkWEYEGZXazTVemWdA9IEjV7LryooS6OsypdNi3rpfLDgGffwZJhjGcA1wWiOpxQkbM8B0VkfNLs24OCLAf1HA==
-    rewardWeightBps: 14_0500
+    rewardWeightBps: 16_0500
     extraBeneficiaries:
       - beneficiary: "bsv-ghost-1::122097db9a94a9682322b80231ee2f5597df9f04b6c49bdc1724157a1de3e15fbd0f" # Bosphorus SV (BSV)  CIP-0093 # escrow party_id hosted on 5nghost-testnet-1
         weight: 6_0000
       - beneficiary: "qcp-ghost-1::122097db9a94a9682322b80231ee2f5597df9f04b6c49bdc1724157a1de3e15fbd0f" # QCP Group (QCP)  CIP-0106 # escrow party_id hosted on 5nghost-testnet-1
         weight: 5_0000
+      - beneficiary: "chainsafe-ghost-1::122097db9a94a9682322b80231ee2f5597df9f04b6c49bdc1724157a1de3e15fbd0f" # ChainSafe  CIP-0086 # escrow party_id hosted on 5nghost-testnet-1
+        weight: 2_0000
   - name: Proof-Group-1
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEX1G0Gc5kYqisXQk0GZpygZ7cOmo5AHh0+87ZVnwPUXdA9msdGm/XCCTfFz4g7x4QfhgXHEARGSTqvIq5PbUqTQ==
     rewardWeightBps: 1_2500


### PR DESCRIPTION
PER CIP-00860

- https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0086/cip-0086.md
- https://lists.sync.global/g/tokenomics-announce/message/295

ChainSafe SV has a max weight of 2 and will be hosted on an escrow validator.

5N reward weight is increased by 2_0000 bps and the extra 2_0000 bps are attributed to the party
chainsafe-ghost-1::122097db9a94a9682322b80231ee2f5597df9f04b6c49bdc1724157a1de3e15fbd0f

This party is hosted on
5nghost-testnet-1 validator with disabled wallet and reward minting.