### PR TITLE
correct weight field for extraBeneficiaries of 5n

### DIFF
--- a/configs/MainNet/approved-sv-id-values.yaml
+++ b/configs/MainNet/approved-sv-id-values.yaml
@@ -161,8 +161,8 @@ approvedSvIdentities:
     rewardWeightBps: 16_0500
     extraBeneficiaries:
       - beneficiary: "bsv-ghost-1::12207f131d493f0fa74e2ae3b2f69b469ebdf2928b84176397b8c983f3f6f6b6f951" # Bosphorus SV (BSV)  CIP-0093 # escrow party_id hosted on 5nghost-mainnet-1
-        rewardWeightBps: 6_0000
+        weight: 6_0000
       - beneficiary: "qcp-ghost-1::12207f131d493f0fa74e2ae3b2f69b469ebdf2928b84176397b8c983f3f6f6b6f951" # QCP Group (QCP)  CIP-0106 # escrow party_id hosted on 5nghost-mainnet-1
-        rewardWeightBps: 5_0000
+        weight: 5_0000
       - beneficiary: "chainsafe-ghost-1::12207f131d493f0fa74e2ae3b2f69b469ebdf2928b84176397b8c983f3f6f6b6f951" # ChainSafe  CIP-0086 # escrow party_id hosted on 5nghost-mainnet-1
-        rewardWeightBps: 2_0000
+        weight: 2_0000


### PR DESCRIPTION
This PR correct the field name that re-present weight of escrow/hosted sv under 5N.

The weight of escrow/hosted are re-present using `weight` and not `rewardWeightBps`.
