### PR TITLE
CIP-0113 Add Further weights to the 5N SV node on DevNet

### DIFF
--- a/configs/DevNet/approved-sv-id-values.yaml
+++ b/configs/DevNet/approved-sv-id-values.yaml
@@ -132,7 +132,7 @@ approvedSvIdentities:
     rewardWeightBps: 10_5750
   - name: Five-North-1
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEVSqn1J3YWij1KBWVNKKOQ8aEPeUc9SFe418mneRdV/PJOX4awAePDrG7A09SYkqP8dyg8ESMw5ltV0dJt5eqlQ==
-    rewardWeightBps: 16_0500
+    rewardWeightBps: 24_0500
     extraBeneficiaries:
       - beneficiary: "bsv-ghost-1::122021b2533a670a0eefc3a68e998ef77f56c0b2dc1ef2f40a8f829122079847931b" # Bosphorus SV (BSV)  CIP-0093 # escrow party_id hosted on 5nghost-devnet-2
         weight: 6_0000
@@ -140,6 +140,8 @@ approvedSvIdentities:
         weight: 5_0000
       - beneficiary: "chainsafe-ghost-1::122021b2533a670a0eefc3a68e998ef77f56c0b2dc1ef2f40a8f829122079847931b" # ChainSafe  CIP-0086 # escrow party_id hosted on 5nghost-devnet-2
         weight: 2_0000
+      - beneficiary: "further-ghost-1::122021b2533a670a0eefc3a68e998ef77f56c0b2dc1ef2f40a8f829122079847931b" # Further Asset Management (Further)  CIP-0113 # escrow party_id hosted on 5nghost-devnet-2
+        weight: 8_0000
   - name: Proof-Group-1
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEeSP06KmTXsRJ65JGYwtzKRX9gosW+Gf4IwIquPGT8+XM1ey9La4wdZ+eELNZMPGacQ9fDe2JPFuRJE+fdVsfOQ==
     rewardWeightBps: 1_2500


### PR DESCRIPTION
PER CIP-0113

https://github.com/canton-foundation/cips/blob/main/cip-0113/cip-0113.md Further SV has a max weight of 8 and will be hosted on an escrow validator.

5N reward weight is increased by 8_0000 bps and the extra 8_0000 bps are attributed to the party
further-ghost-1::122021b2533a670a0eefc3a68e998ef77f56c0b2dc1ef2f40a8f829122079847931b

This party is hosted on 5nghost-devnet-2 validator with disabled wallet and reward minting.