### PR TITLE
CIP-0113 Add Further weights to the 5N SV node on MainNet

### DIFF
--- a/configs/MainNet/approved-sv-id-values.yaml
+++ b/configs/MainNet/approved-sv-id-values.yaml
@@ -158,7 +158,7 @@ approvedSvIdentities:
     rewardWeightBps: 10_0000
   - name: Five-North-1
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEGe25jhw59y0TXgGkEmWLgCjG9D3yq4GweHzGLQ7cnbNVUqiG/ndXeFLJG1rQy6a+Ky0XfJDdcs8yCvbbsV+qqg==
-    rewardWeightBps: 16_0500
+    rewardWeightBps: 24_0500
     extraBeneficiaries:
       - beneficiary: "bsv-ghost-1::12207f131d493f0fa74e2ae3b2f69b469ebdf2928b84176397b8c983f3f6f6b6f951" # Bosphorus SV (BSV)  CIP-0093 # escrow party_id hosted on 5nghost-mainnet-1
         weight: 6_0000
@@ -166,3 +166,5 @@ approvedSvIdentities:
         weight: 5_0000
       - beneficiary: "chainsafe-ghost-1::12207f131d493f0fa74e2ae3b2f69b469ebdf2928b84176397b8c983f3f6f6b6f951" # ChainSafe  CIP-0086 # escrow party_id hosted on 5nghost-mainnet-1
         weight: 2_0000
+      - beneficiary: "further-ghost-1::12207f131d493f0fa74e2ae3b2f69b469ebdf2928b84176397b8c983f3f6f6b6f951" # Further Asset Management (Further)  CIP-0113 # escrow party_id hosted on 5nghost-mainnet-1
+        weight: 8_0000


### PR DESCRIPTION
PER CIP-0113

https://github.com/canton-foundation/cips/blob/main/cip-0113/cip-0113.md Further SV has a max weight of 8 and will be hosted on an escrow validator.

5N reward weight is increased by 8_0000 bps and the extra 8_0000 bps are attributed to the party
further-ghost-1::12207f131d493f0fa74e2ae3b2f69b469ebdf2928b84176397b8c983f3f6f6b6f951

This party is hosted on 5nghost-mainnet-1 validator with disabled wallet and reward minting.