### PR TITLE
CIP-0109 Add Visa weight to the MPC-Holding-Inc SV node on MainNet [allow-total-reward-weight-change]

### DIFF
--- a/configs/MainNet/approved-sv-id-values.yaml
+++ b/configs/MainNet/approved-sv-id-values.yaml
@@ -122,7 +122,7 @@ approvedSvIdentities:
     rewardWeightBps: 15_9250
   - name: MPC-Holding-Inc
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPuCFe1z5+ZzVb9y78ewt9yYm7KjGlCk36nF5ZrkkoO+lZvAXmr0IEWEgtBHxienC2IIDGT49aQM6M8ukvbxYLA==
-    rewardWeightBps: 14_0000
+    rewardWeightBps: 24_0000
     extraBeneficiaries:
       - beneficiary: "auth0_007c66f47b4f7dbebab8f2af6967::12204783725aa3adcd787311531134baed8b9b28ccf76b100c62b8d4995842aabd6b" # MPCH
         weight: 1_0000
@@ -136,6 +136,8 @@ approvedSvIdentities:
         weight: "50000"
       - beneficiary: "Tharimmune-ghost-1::12202639480c7e95ab18e696d83cdaa87cb5b92b935698ae4e69fb9cbfa2808d47ff" # Tharimmune, Inc. CIP-0102 # escrow party_id added to the MPCH-GHOSTvalidator-1
         weight: 4_0000
+      - beneficiary: "Visa-Escrow-1::12202639480c7e95ab18e696d83cdaa87cb5b92b935698ae4e69fb9cbfa2808d47ff" # Visa CIP-0109 # escrow party_id added to the MPCH-GHOSTvalidator-1
+        weight: 10_0000
   - name: Orb-1-LP-1
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYSpqOpqB6lWVLfu7ojM/GTSALZK2X1MAKhJoZIJP+G7WkDo0Hap4VZtaSyrKiTqlcKu4ycgJ5UEG1WAkoKYjOA==
     rewardWeightBps: 10_0000


### PR DESCRIPTION
https://lists.sync.global/g/cip-announce/topic/118462808

The vote expires on 04/22/2026 03:20:57 PM UTC +1
The vote becomes effective on 04/23/2026 03:21:00 PM UTC +1