### PR TITLE
CIP-0086 Add Chainsafe weight for the completed milestone(s) on MainNet

### DIFF
--- a/configs/MainNet/approved-sv-id-values.yaml
+++ b/configs/MainNet/approved-sv-id-values.yaml
@@ -158,7 +158,7 @@ approvedSvIdentities:
     rewardWeightBps: 10_0000
   - name: Five-North-1
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEGe25jhw59y0TXgGkEmWLgCjG9D3yq4GweHzGLQ7cnbNVUqiG/ndXeFLJG1rQy6a+Ky0XfJDdcs8yCvbbsV+qqg==
-    rewardWeightBps: 16_0500
+    rewardWeightBps: 18_0000
     extraBeneficiaries:
       - beneficiary: "bsv-ghost-1::12207f131d493f0fa74e2ae3b2f69b469ebdf2928b84176397b8c983f3f6f6b6f951" # Bosphorus SV (BSV)  CIP-0093 # escrow party_id hosted on 5nghost-mainnet-1
         weight: 6_0000
@@ -166,3 +166,5 @@ approvedSvIdentities:
         weight: 5_0000
       - beneficiary: "chainsafe-ghost-1::12207f131d493f0fa74e2ae3b2f69b469ebdf2928b84176397b8c983f3f6f6b6f951" # ChainSafe  CIP-0086 # escrow party_id hosted on 5nghost-mainnet-1
         weight: 2_0000
+      - beneficiary: "chainsafe-sv-0::122043f0b94e28125e4c65aa7e0f0ded912472731695f01cc83aa41ad3f03965a19b" # ChainSafe  CIP-0086 # active party_id used to receive an earned weight for completed milestone(s)
+        weight: 1_9500


### PR DESCRIPTION
According to [this announcement](https://lists.sync.global/g/tokenomics-announce/message/295), Chainsafe has met milestones for `ERC-20 Middleware MVP Complete and Available on MainNet` (1.0) AND partially met `Acceleration Bonus` (0.95 out of 2.0) for a total of 1_9500 basis points.

Following [CIP-0086: Native ERC‑20 Middleware for Canton Network](https://lists.sync.global/g/cip-discuss/topic/cip_xxxx_native_erc_20/115263542), Fivenorth adds weight for completed milestones to Chainsafe's separate party, on a separate Validator from the ghost SV validator, to mint its weight of 1.95.