### PR TITLE
CIP-0086 Add Chainsafe weight for the completed milestone(s) on DevNet

### DIFF
--- a/configs/DevNet/approved-sv-id-values.yaml
+++ b/configs/DevNet/approved-sv-id-values.yaml
@@ -132,7 +132,7 @@ approvedSvIdentities:
     rewardWeightBps: 10_5750
   - name: Five-North-1
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEVSqn1J3YWij1KBWVNKKOQ8aEPeUc9SFe418mneRdV/PJOX4awAePDrG7A09SYkqP8dyg8ESMw5ltV0dJt5eqlQ==
-    rewardWeightBps: 16_0500
+    rewardWeightBps: 18_0000
     extraBeneficiaries:
       - beneficiary: "bsv-ghost-1::122021b2533a670a0eefc3a68e998ef77f56c0b2dc1ef2f40a8f829122079847931b" # Bosphorus SV (BSV)  CIP-0093 # escrow party_id hosted on 5nghost-devnet-2
         weight: 6_0000
@@ -140,6 +140,8 @@ approvedSvIdentities:
         weight: 5_0000
       - beneficiary: "chainsafe-ghost-1::122021b2533a670a0eefc3a68e998ef77f56c0b2dc1ef2f40a8f829122079847931b" # ChainSafe  CIP-0086 # escrow party_id hosted on 5nghost-devnet-2
         weight: 2_0000
+      - beneficiary: "chainsafe-dev-sv-0::1220096316d4ea75c021d89123cfd2792cfeac80dfbf90bfbca21bcd8bf1bb40d84c" # ChainSafe  CIP-0086 # active party_id used to receive an earned weight for completed milestone(s)
+        weight: 1_9500
   - name: Proof-Group-1
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEeSP06KmTXsRJ65JGYwtzKRX9gosW+Gf4IwIquPGT8+XM1ey9La4wdZ+eELNZMPGacQ9fDe2JPFuRJE+fdVsfOQ==
     rewardWeightBps: 1_2500


### PR DESCRIPTION
According to [this announcement](https://lists.sync.global/g/tokenomics-announce/message/295), Chainsafe has met milestones for ERC-20 Middleware MVP Complete and Available on MainNet (1.0) AND partially met Acceleration Bonus (0.95 out of 2.0) for a total of 1_9500 basis points.

Following [CIP-0086: Native ERC‑20 Middleware](https://lists.sync.global/g/cip-discuss/topic/cip_xxxx_native_erc_20/115263542) for Canton Network, Fivenorth adds weight for completed milestones to Chainsafe's separate party, on a separate Validator from the ghost SV validator, to mint its weight of 1.95.