### PR TITLE
chore: update MPC-Holding-Inc extraBeneficiaries split on TestNet

### DIFF
--- a/configs/TestNet/approved-sv-id-values.yaml
+++ b/configs/TestNet/approved-sv-id-values.yaml
@@ -106,8 +106,10 @@ approvedSvIdentities:
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEOxCYWSBB4hDz7O1XxJ3xswKXxJcQqsgyzBTbWjkwa+ILYXy8T2vtVMoZ+tC/Ykdp3MyFwcMIP1kzcDKCSp0qow==
     rewardWeightBps: 24_0000
     extraBeneficiaries:
-      - beneficiary: "auth0_007c66f44bc7589a682afe95a21d::12208fdbf6156f607c104512ce12fcb382ce3ec3116e7aa5ddb02b7fce237efd4843" # MPCH
-        weight: 1_0000
+      - beneficiary: "auth0_007c66f44bc7589a682afe95a21d::12200a154afee0ada3b0cc9139e4356187d8c62747f2a9584b1893a47280f31a5ce1" # MPCH
+        weight: 3000
+      - beneficiary: "auth0_007c69c66553a56244a41fe1372e::12203f851adf882ea3176ecc26f00a65146fb5a0516806cb727df017bd6284c01e0b"
+        weight: 7000
       - beneficiary: "HexTrust-ghost-1::1220804f8856b9ec277d69059ce8ea31063dbec116b0c398c2ff3d191b0f227ef04b" # HexTrust CIP-0087 # escrow party_id added to the MPCH-GHOSTvalidator-1
         weight: 3_0000
       - beneficiary: "Blockdaemon-ghost-1::1220804f8856b9ec277d69059ce8ea31063dbec116b0c398c2ff3d191b0f227ef04b" # Blockdaemon CIP-0094 # escrow party_id added to the MPCH-GHOSTvalidator-1


### PR DESCRIPTION
Update MPC-Holding-Inc extraBeneficiaries: changed the main MPCH SV rewards partyID and changed the weight to 3000; added a locking wallet for MPCH with 7000 weight.