### PR TITLE
CIP-0114 Add Canton Strategic Holdings/Tharimmune weight on DevNet

### DIFF
--- a/configs/DevNet/approved-sv-id-values.yaml
+++ b/configs/DevNet/approved-sv-id-values.yaml
@@ -113,14 +113,14 @@ approvedSvIdentities:
         weight: 10_0000
   - name: MPC-Holding-Inc
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEgWriOYpZeYXC09cPOKm/s1MzZSrJvKZc3Mz4RqYLsA7j/umQfLFKqWWu1TT77JrrGTTp57aXUTcrGg0DvyRq/Q==
-    rewardWeightBps: 24_0000
+    rewardWeightBps: 35_0000
     extraBeneficiaries:
       - beneficiary: "HexTrust-ghost-1::1220a816c3b1810840b0f40f74f3728e4f0d15fc4d15a472aab8bcdad796616e831c" # HexTrust CIP-0087 # escrow party_id added to the MPCH-GHOSTvalidator-1
         weight: 3_0000
       - beneficiary: "Blockdaemon-ghost-1::1220a816c3b1810840b0f40f74f3728e4f0d15fc4d15a472aab8bcdad796616e831c" # Blockdaemon CIP-0094 # escrow party_id added to the MPCH-GHOSTvalidator-1
         weight: "50000"
       - beneficiary: "Tharimmune-ghost-1::1220a816c3b1810840b0f40f74f3728e4f0d15fc4d15a472aab8bcdad796616e831c" # Tharimmune, Inc. CIP-0102 # escrow party_id added to the MPCH-GHOSTvalidator-1
-        weight: 4_0000
+        weight: 15_0000
       - beneficiary: "Visa-Escrow-1::1220a816c3b1810840b0f40f74f3728e4f0d15fc4d15a472aab8bcdad796616e831c" # Visa CIP-0109 # escrow party_id added to the MPCH-GHOSTvalidator-1
         weight: 10_0000
   - name: Tradeweb-Markets-1


### PR DESCRIPTION
According to this announcement 
[(https://lists.sync.global/g/tokenomicsannounce/topic/tokenomics_outcomes_april/119083656)]

Canton Strategic Holdings/Tharimmune has met milestones for CIP-0114 adding additional 11_000 basis points for a total of 14_000 basis points on DevNet. 

Following [https://github.com/canton-foundation/cips/blob/main/cip-0114/cip-0114.md] 

MPC-Holding-Inc adds weight for completed requirements to Canton Strategic Holdings/Tharimmune's ghost SV validator, to mint its weight of 15_000


https://lists.sync.global/g/supervalidator-announce/message/506
https://sv.sv-1.dev.iap.mpch.io/governance/proposals/0056ea5409df5fa83c08e7e6e60ce51c2d35b2cce974327e0b86b34a9d6affe438ca121220cb21c92fdb726480222d0dd76e80892638c7b49335cf01bf3955c82ed7f754eb