### PR TITLE
CIP-0114 Add Canton Strategic Holdings/Tharimmune weight on TestNet

### DIFF
--- a/configs/TestNet/approved-sv-id-values.yaml
+++ b/configs/TestNet/approved-sv-id-values.yaml
@@ -104,7 +104,7 @@ approvedSvIdentities:
         weight: 10_0000
   - name: MPC-Holding-Inc
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEOxCYWSBB4hDz7O1XxJ3xswKXxJcQqsgyzBTbWjkwa+ILYXy8T2vtVMoZ+tC/Ykdp3MyFwcMIP1kzcDKCSp0qow==
-    rewardWeightBps: 24_0000
+    rewardWeightBps: 35_0000
     extraBeneficiaries:
       - beneficiary: "auth0_007c66f44bc7589a682afe95a21d::12208fdbf6156f607c104512ce12fcb382ce3ec3116e7aa5ddb02b7fce237efd4843" # MPCH
         weight: 1_0000
@@ -113,7 +113,7 @@ approvedSvIdentities:
       - beneficiary: "Blockdaemon-ghost-1::1220804f8856b9ec277d69059ce8ea31063dbec116b0c398c2ff3d191b0f227ef04b" # Blockdaemon CIP-0094 # escrow party_id added to the MPCH-GHOSTvalidator-1
         weight: "50000"
       - beneficiary: "Tharimmune-ghost-1::1220804f8856b9ec277d69059ce8ea31063dbec116b0c398c2ff3d191b0f227ef04b" # Tharimmune, Inc. CIP-0102 # escrow party_id added to the MPCH-GHOSTvalidator-1
-        weight: 4_0000
+        weight: 15_0000
       - beneficiary: "Visa-Escrow-1::1220804f8856b9ec277d69059ce8ea31063dbec116b0c398c2ff3d191b0f227ef04b" # Visa CIP-0109 # escrow party_id added to the MPCH-GHOSTvalidator-1
         weight: 10_0000
   - name: Orb-1-LP-1


### PR DESCRIPTION
According to this announcement 
[https://lists.sync.global/g/tokenomics-announce/topic/tokenomics_outcomes_april/119083656]

Canton Strategic Holdings/Tharimmune has met milestones for CIP-0114 adding additional 11_000 basis points for a total of 15_000 basis points on TestNet. 

Following [https://github.com/canton-foundation/cips/blob/main/cip-0114/cip-0114.md] 

MPC-Holding-Inc adds weight for completed requirements to Canton Strategic Holdings/Tharimmune's ghost SV validator, to mint its weight of 15_000

https://sv.sv-1.test.iap.mpch.io/governance/proposals/001445487a9e7ad3a04c13745235271f424472f53ab3f730ec1aadd040083c496dca12122034d5109968096d8a9260ada6e8578e1200dd29ef19410c60aa85fcb1cbd13fb3