### PR TITLE
CIP-0114 Add Canton Strategic Holdings/Tharimmune weight on MainNet

### DIFF
--- a/configs/MainNet/approved-sv-id-values.yaml
+++ b/configs/MainNet/approved-sv-id-values.yaml
@@ -122,7 +122,7 @@ approvedSvIdentities:
     rewardWeightBps: 15_9250
   - name: MPC-Holding-Inc
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPuCFe1z5+ZzVb9y78ewt9yYm7KjGlCk36nF5ZrkkoO+lZvAXmr0IEWEgtBHxienC2IIDGT49aQM6M8ukvbxYLA==
-    rewardWeightBps: 24_0000
+    rewardWeightBps: 35_0000
     extraBeneficiaries:
       - beneficiary: "auth0_007c66f47b4f7dbebab8f2af6967::12204783725aa3adcd787311531134baed8b9b28ccf76b100c62b8d4995842aabd6b" # MPCH - wallet
         weight: 5500
@@ -141,7 +141,7 @@ approvedSvIdentities:
       - beneficiary: "Blockdaemon-ghost-1::12202639480c7e95ab18e696d83cdaa87cb5b92b935698ae4e69fb9cbfa2808d47ff" # Blockdaemon CIP-0094 # escrow party_id added to the MPCH-GHOSTvalidator-1
         weight: "50000"
       - beneficiary: "Tharimmune-ghost-1::12202639480c7e95ab18e696d83cdaa87cb5b92b935698ae4e69fb9cbfa2808d47ff" # Tharimmune, Inc. CIP-0102 # escrow party_id added to the MPCH-GHOSTvalidator-1
-        weight: 4_0000
+        weight: 15_0000
       - beneficiary: "Visa-Escrow-1::12202639480c7e95ab18e696d83cdaa87cb5b92b935698ae4e69fb9cbfa2808d47ff" # Visa CIP-0109 # escrow party_id added to the MPCH-GHOSTvalidator-1
         weight: 10_0000
   - name: Orb-1-LP-1


### PR DESCRIPTION
According to this announcement 
[https://lists.sync.global/g/tokenomics-announce/topic/tokenomics_outcomes_april/119083656]


Canton Strategic Holdings/Tharimmune has met milestones for CIP-0114 adding additional 11_000 basis points for a total of 15_000 basis points on TestNet. 

Following [https://github.com/canton-foundation/cips/blob/main/cip-0114/cip-0114.md] 

MPC-Holding-Inc adds weight for completed requirements to Canton Strategic Holdings/Tharimmune's ghost SV validator, to mint its weight of 15_000

https://sv.sv-1.iap.mpch.io/governance/proposals/00d8b6a071a3c960b37adeccf6d2e9bc721b32745ff763e2152886b8b44fa9d3c5ca12122086eca8d7b9874fa9cfcd7938b49dfc19650b1c3604e0d1e4623f29e20ee5c0fe