### PR TITLE
CIP-0061 Update Chainlink weight for the completed milestone(s) (as per Tokenomics Meeting Outcomes May 6, 2026)

### DIFF
--- a/configs/DevNet/approved-sv-id-values.yaml
+++ b/configs/DevNet/approved-sv-id-values.yaml
@@ -63,7 +63,7 @@ approvedSvIdentities:
         weight: 1_5000
       - beneficiary: "Hypernative-ghost-1::1220a9cc88707f22cdad61f2cacc5edea9820daf21b70dc9744171f28e9b5b3c30f7" # Hypernative CIP-0076 # escrow party_id added to the GhostSV-validator-1
         weight: 1_0000
-      - beneficiary: "Chainlink-ghost-1::1220a9cc88707f22cdad61f2cacc5edea9820daf21b70dc9744171f28e9b5b3c30f7" # Chainlink CIP-0061 # escrow party_id added to the GhostSV-validator-1
+      - beneficiary: "Chainlink-ghost-1::1220a9cc88707f22cdad61f2cacc5edea9820daf21b70dc9744171f28e9b5b3c30f7" # Chainlink CIP-0061
         weight: 7_5000
       - beneficiary: "Chainlink-ghost-2::1220a9cc88707f22cdad61f2cacc5edea9820daf21b70dc9744171f28e9b5b3c30f7" # Chainlink CIP-0065 # escrow party_id added to the GhostSV-validator-1
         weight: 3_0000

--- a/configs/MainNet/approved-sv-id-values.yaml
+++ b/configs/MainNet/approved-sv-id-values.yaml
@@ -55,10 +55,8 @@ approvedSvIdentities:
         weight: 1_5000
       - beneficiary: "hypernative-validator-1::122055c3d9a3ac09fbeb9fcb9da8ab1582ccf3844220adda46ef99ef946513b40f75" # Hypernative CIP-0076
         weight: 1_0000
-      - beneficiary: "Chainlink-Mainnet-1::1220dd5b27f9e0459ec77822784d0e9b6c106fe4a71e9d5c19bd8ac574d2ab02f50e" # Chainlink CIP-0061 # active party_id used to receive an earned weight for completed milestone(s)
-        weight: 7_0000
-      - beneficiary: "Chainlink-ghost-1::1220f5cf298f609f538b46a2a0347d299028ddca7ea008aaed65e0ca862db974c5e2" # Chainlink CIP-0061 # escrow party_id added to the GhostSV-validator-1
-        weight: 0_5000
+      - beneficiary: "Chainlink-Mainnet-1::1220dd5b27f9e0459ec77822784d0e9b6c106fe4a71e9d5c19bd8ac574d2ab02f50e" # Chainlink CIP-0061
+        weight: 7_5000
       - beneficiary: "Chainlink-ghost-2::1220f5cf298f609f538b46a2a0347d299028ddca7ea008aaed65e0ca862db974c5e2" # Chainlink CIP-0065 # escrow party_id added to the GhostSV-validator-1
         weight: 3_0000
       - beneficiary: "LayerZero-ghost-1::1220f5cf298f609f538b46a2a0347d299028ddca7ea008aaed65e0ca862db974c5e2" # Layer Zero CIP-0065 # escrow party_id added to the GhostSV-validator-1

--- a/configs/TestNet/approved-sv-id-values.yaml
+++ b/configs/TestNet/approved-sv-id-values.yaml
@@ -54,7 +54,7 @@ approvedSvIdentities:
         weight: 1_5000
       - beneficiary: "Hypernative-ghost-1::1220d1c3265d2d5e43ddb1dda4fbb42a1b3780c94ebd86c5aac178845fc9ddec90ef" # Hypernative CIP-0076 # escrow party_id added to the GhostSV-validator-1
         weight: 1_0000
-      - beneficiary: "Chainlink-ghost-1::1220d1c3265d2d5e43ddb1dda4fbb42a1b3780c94ebd86c5aac178845fc9ddec90ef" # Chainlink CIP-0061 # escrow party_id added to the GhostSV-validator-1
+      - beneficiary: "Chainlink-ghost-1::1220d1c3265d2d5e43ddb1dda4fbb42a1b3780c94ebd86c5aac178845fc9ddec90ef" # Chainlink CIP-0061
         weight: 7_5000
       - beneficiary: "Chainlink-ghost-2::1220d1c3265d2d5e43ddb1dda4fbb42a1b3780c94ebd86c5aac178845fc9ddec90ef" # Chainlink CIP-0065 # escrow party_id added to the GhostSV-validator-1
         weight: 3_0000


### PR DESCRIPTION
Following the recent [announcement](https://lists.sync.global/g/tokenomics-announce/message/323), Chainlink has successfully achieved a new milestone under the [Adoption Incentives](https://github.com/canton-foundation/cips/blob/main/cip-0061/cip-0061.md#deliverables-for-full-sv-reward) framework.

Effective May 7, 2026, at 12:00 UTC, GSF has increased the Chainlink weight by 0.5, bringing its total minting weight to 7.5.

Since the full weight has now been allocated, the temporary escrow party ID has been removed from the `extraBeneficiaries` configuration and replaced with the verified party ID.