### PR TITLE
CIP-0111 Remove Monstera FZE and Woodside AI weights from the GSF SV …

### DIFF
--- a/configs/DevNet/approved-sv-id-values.yaml
+++ b/configs/DevNet/approved-sv-id-values.yaml
@@ -19,7 +19,7 @@ approvedSvIdentities:
     rewardWeightBps: 15_9250
   - name: Global-Synchronizer-Foundation
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE+2XaCekgPDPoEzXeo3yYf6Y+3zbIXKMoR2WYl/pa8CMuOloMXHUfdi6viBJcvoLij7ti5PaqLp1PHJ5tWLteVQ==
-    rewardWeightBps: 200_6000
+    rewardWeightBps: 185_6000
     extraBeneficiaries:
       - beneficiary: "GhostSV-validator-1::1220a9cc88707f22cdad61f2cacc5edea9820daf21b70dc9744171f28e9b5b3c30f7" # All weight not assigned to any particular SV is added to the GhostSV-validator-1; 0.05 (Ubyx) + 0.92 (Fireblocks) + 0.0917 (Talos) + 0.1333 (BitGo)
         weight: 1_1950
@@ -45,10 +45,6 @@ approvedSvIdentities:
         weight: 1_0000
       - beneficiary: "figment-devnet-validator-1::12200a16a17dd793b33b61b503fb291bd21e08d856a6d383b2034d1c2ef47977268a" # Figment CIP-0054
         weight: 1_0000
-      - beneficiary: "MonsteraFZE-ghost-1::1220a9cc88707f22cdad61f2cacc5edea9820daf21b70dc9744171f28e9b5b3c30f7" # Monstera FZE CIP-0052 # escrow party_id added to the GhostSV-validator-1
-        weight: 5_0000
-      - beneficiary: "WoodsideAI-ghost-1::1220a9cc88707f22cdad61f2cacc5edea9820daf21b70dc9744171f28e9b5b3c30f7" # Woodside AI CIP-0059 # escrow party_id added to the GhostSV-validator-1
-        weight: 10_0000
       - beneficiary: "zhstaking-devnet::1220a5c87858708e08b30406776502d2506fdf9b9961195e6008fc04eca6fee9f0a7" # Zero Hash CIP-0060 # active party_id used to receive an earned weight for completed milestone(s)
         weight: 3_5000
       - beneficiary: "ZeroHash-ghost-1::1220a9cc88707f22cdad61f2cacc5edea9820daf21b70dc9744171f28e9b5b3c30f7" # Zero Hash CIP-0060 # escrow party_id added to the GhostSV-validator-1


### PR DESCRIPTION
The vote expires on 2026-05-14 11:00 UTC
The vote becomes effective on 2026-05-15 11:00 UTC