### PR TITLE
CIP-0110 Add Apollo weights to the 5N SV node on DevNet

### DIFF
--- a/configs/DevNet/approved-sv-id-values.yaml
+++ b/configs/DevNet/approved-sv-id-values.yaml
@@ -134,7 +134,7 @@ approvedSvIdentities:
     rewardWeightBps: 10_5750
   - name: Five-North-1
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEVSqn1J3YWij1KBWVNKKOQ8aEPeUc9SFe418mneRdV/PJOX4awAePDrG7A09SYkqP8dyg8ESMw5ltV0dJt5eqlQ==
-    rewardWeightBps: 24_0500
+    rewardWeightBps: 31_0500
     extraBeneficiaries:
       - beneficiary: "bsv-ghost-1::122021b2533a670a0eefc3a68e998ef77f56c0b2dc1ef2f40a8f829122079847931b" # Bosphorus SV (BSV)  CIP-0093 # escrow party_id hosted on 5nghost-devnet-2
         weight: 6_0000
@@ -144,6 +144,8 @@ approvedSvIdentities:
         weight: 2_0000
       - beneficiary: "further-ghost-1::122021b2533a670a0eefc3a68e998ef77f56c0b2dc1ef2f40a8f829122079847931b" # Further Asset Management (Further)  CIP-0113 # escrow party_id hosted on 5nghost-devnet-2
         weight: 8_0000
+      - beneficiary: "apollo-ghost-1::122021b2533a670a0eefc3a68e998ef77f56c0b2dc1ef2f40a8f829122079847931b" # Apollo Global Management (Apollo)  CIP-0110 # escrow party_id hosted on 5nghost-devnet-2
+        weight: 7_0000
   - name: Proof-Group-1
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEeSP06KmTXsRJ65JGYwtzKRX9gosW+Gf4IwIquPGT8+XM1ey9La4wdZ+eELNZMPGacQ9fDe2JPFuRJE+fdVsfOQ==
     rewardWeightBps: 1_2500

--- a/configs/DevNet/approved-sv-id-values.yaml
+++ b/configs/DevNet/approved-sv-id-values.yaml
@@ -130,7 +130,7 @@ approvedSvIdentities:
     rewardWeightBps: 10_5750
   - name: Five-North-1
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEVSqn1J3YWij1KBWVNKKOQ8aEPeUc9SFe418mneRdV/PJOX4awAePDrG7A09SYkqP8dyg8ESMw5ltV0dJt5eqlQ==
-    rewardWeightBps: 31_0500
+    rewardWeightBps: 33_0000
     extraBeneficiaries:
       - beneficiary: "bsv-ghost-1::122021b2533a670a0eefc3a68e998ef77f56c0b2dc1ef2f40a8f829122079847931b" # Bosphorus SV (BSV)  CIP-0093 # escrow party_id hosted on 5nghost-devnet-2
         weight: 6_0000
@@ -140,6 +140,8 @@ approvedSvIdentities:
         weight: 2_0000
       - beneficiary: "further-ghost-1::122021b2533a670a0eefc3a68e998ef77f56c0b2dc1ef2f40a8f829122079847931b" # Further Asset Management (Further)  CIP-0113 # escrow party_id hosted on 5nghost-devnet-2
         weight: 8_0000
+      - beneficiary: "chainsafe-dev-sv-0::1220096316d4ea75c021d89123cfd2792cfeac80dfbf90bfbca21bcd8bf1bb40d84c" # ChainSafe  CIP-0086 # active party_id used to receive an earned weight for completed milestone(s)
+        weight: 1_9500
       - beneficiary: "apollo-ghost-1::122021b2533a670a0eefc3a68e998ef77f56c0b2dc1ef2f40a8f829122079847931b" # Apollo Global Management (Apollo)  CIP-0110 # escrow party_id hosted on 5nghost-devnet-2
         weight: 7_0000
   - name: Proof-Group-1


### PR DESCRIPTION
PER CIP-0110

https://github.com/canton-foundation/cips/blob/main/cip-0110/cip-0110.md Apollo SV has a max weight of 7 and will be hosted on an escrow validator.

5N reward weight is increased by 7_0000 bps and the extra 7_0000 bps are attributed to the party
apollo-ghost-1::122021b2533a670a0eefc3a68e998ef77f56c0b2dc1ef2f40a8f829122079847931b

This party is hosted on 5nghost-devnet-2 validator with disabled wallet and reward minting.

**Note** that this commit also addresses the discrepancy between networks for Fivenorth SV due to [Chainsafe's](https://lighthouse.devnet.cantonloop.com/governance/00e846512d926062768b9c57b396a0ade469cdfba08c917a7ad96a2bacbcd01b3dca1212201847d1bcb23507de99ee11fb3cbad584ceefcce2648b224b8be8d83f6cfb5d92) failed vote.