### PR TITLE
CIP-0110 Add Apollo weights to the 5N SV node on MainNet

### DIFF
--- a/configs/MainNet/approved-sv-id-values.yaml
+++ b/configs/MainNet/approved-sv-id-values.yaml
@@ -180,7 +180,7 @@ approvedSvIdentities:
         weight: 7_0000
   - name: Five-North-1
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEGe25jhw59y0TXgGkEmWLgCjG9D3yq4GweHzGLQ7cnbNVUqiG/ndXeFLJG1rQy6a+Ky0XfJDdcs8yCvbbsV+qqg==
-    rewardWeightBps: 26_0000
+    rewardWeightBps: 33_0000
     extraBeneficiaries:
       - beneficiary: "bsv-ghost-1::12207f131d493f0fa74e2ae3b2f69b469ebdf2928b84176397b8c983f3f6f6b6f951" # Bosphorus SV (BSV)  CIP-0093 # escrow party_id hosted on 5nghost-mainnet-1
         weight: 6_0000
@@ -192,3 +192,5 @@ approvedSvIdentities:
         weight: 8_0000
       - beneficiary: "chainsafe-sv-0::122043f0b94e28125e4c65aa7e0f0ded912472731695f01cc83aa41ad3f03965a19b" # ChainSafe  CIP-0086 # active party_id used to receive an earned weight for completed milestone(s)
         weight: 1_9500
+      - beneficiary: "apollo-ghost-1::12207f131d493f0fa74e2ae3b2f69b469ebdf2928b84176397b8c983f3f6f6b6f951" # Apollo Global Management (Apollo)  CIP-0110 # escrow party_id hosted on 5nghost-mainnet-1
+        weight: 7_0000


### PR DESCRIPTION
PER CIP-0110

https://github.com/canton-foundation/cips/blob/main/cip-0110/cip-0110.md Apollo SV has a max weight of 7 and will be hosted on an escrow validator.

5N reward weight is increased by 7_0000 bps and the extra 7_0000 bps are attributed to the party
apollo-ghost-1::12207f131d493f0fa74e2ae3b2f69b469ebdf2928b84176397b8c983f3f6f6b6f951

This party is hosted on 5nghost-mainnet-1 validator with disabled wallet and reward minting.