### PR TITLE
CIP-0072 Fireblocks: earned weight increase for a completed milestone (as per Tokenomics Meeting Outcomes June 10, 2026)

### DIFF
--- a/configs/DevNet/approved-sv-id-values.yaml
+++ b/configs/DevNet/approved-sv-id-values.yaml
@@ -21,8 +21,8 @@ approvedSvIdentities:
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE+2XaCekgPDPoEzXeo3yYf6Y+3zbIXKMoR2WYl/pa8CMuOloMXHUfdi6viBJcvoLij7ti5PaqLp1PHJ5tWLteVQ==
     rewardWeightBps: 188_1000
     extraBeneficiaries:
-      - beneficiary: "GhostSV-validator-1::1220a9cc88707f22cdad61f2cacc5edea9820daf21b70dc9744171f28e9b5b3c30f7" # All weight not assigned to any particular SV is added to the GhostSV-validator-1; 0.05 (Ubyx) + 0.92 (Fireblocks) + 0.0917 (Talos) + 0.1333 (BitGo)
-        weight: 1_1950
+      - beneficiary: "GhostSV-validator-1::1220a9cc88707f22cdad61f2cacc5edea9820daf21b70dc9744171f28e9b5b3c30f7" # All weight not assigned to any particular SV is added to the GhostSV-validator-1; 0.05 (Ubyx) + 2.42 (Fireblocks) + 0.0917 (Talos) + 0.1333 (BitGo)
+        weight: 2_6950
       - beneficiary: "GSF-validator-1::12203b389175d5d9a67a443078b3867fb179fc730d5dfb6aca3c509c37e926a6e24b" # GSF-1
         weight: 10_0000
       - beneficiary: "TheTie-validator-1::1220944b4dab3e3436c9ca6c331b6c9b11d908d71db471e44bc5d0bce6b5e81a796e" # The-Tie
@@ -71,10 +71,8 @@ approvedSvIdentities:
         weight: 3_0000
       - beneficiary: "Taurus-ghost-1::1220a9cc88707f22cdad61f2cacc5edea9820daf21b70dc9744171f28e9b5b3c30f7" # Taurus CIP-0077 # escrow party_id added to the GhostSV-validator-1
         weight: 2_0000
-      - beneficiary: "Fireblocks-ghost-1::1220a9cc88707f22cdad61f2cacc5edea9820daf21b70dc9744171f28e9b5b3c30f7" # Fireblocks CIP-0072 # active party_id used to receive an earned weight for completed milestone(s)
-        weight: 2_0800
-      - beneficiary: "Fireblocks-ghost-1::1220a9cc88707f22cdad61f2cacc5edea9820daf21b70dc9744171f28e9b5b3c30f7" # Fireblocks CIP-0072 # escrow party_id added to the GhostSV-validator-1
-        weight: 2_0000
+      - beneficiary: "Fireblocks-ghost-1::1220a9cc88707f22cdad61f2cacc5edea9820daf21b70dc9744171f28e9b5b3c30f7" # Fireblocks CIP-0072
+        weight: 2_5800
       - beneficiary: "BitGo-ghost-1::1220a9cc88707f22cdad61f2cacc5edea9820daf21b70dc9744171f28e9b5b3c30f7" # BitGo CIP-0074 # active party_id used to receive an earned weight for completed milestone(s)
         weight: 2_8667
       - beneficiary: "BitGo-ghost-1::1220a9cc88707f22cdad61f2cacc5edea9820daf21b70dc9744171f28e9b5b3c30f7" # BitGo CIP-0074 # escrow party_id added to the GhostSV-validator-1

--- a/configs/MainNet/approved-sv-id-values.yaml
+++ b/configs/MainNet/approved-sv-id-values.yaml
@@ -3,8 +3,8 @@ approvedSvIdentities:
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEmWLDU/xZzCtl6prd15Dyi+2/zMtSbHpQh8wJ/R3J9YKDVNpkJVo+qBkmYYSdlAifLz1aymUKqZlWDBvtQCJIaA==
     rewardWeightBps: 188_1000
     extraBeneficiaries:
-      - beneficiary: "GhostSV-validator-1::1220f5cf298f609f538b46a2a0347d299028ddca7ea008aaed65e0ca862db974c5e2" # All weight not assigned to any particular SV is added to the GhostSV-validator-1; 0.05 (Ubyx) + 0.92 (Fireblocks) + 0.0917 (Talos) + 0.1333 (BitGo)
-        weight: 1_1950
+      - beneficiary: "GhostSV-validator-1::1220f5cf298f609f538b46a2a0347d299028ddca7ea008aaed65e0ca862db974c5e2" # All weight not assigned to any particular SV is added to the GhostSV-validator-1; 0.05 (Ubyx) + 2.42 (Fireblocks) + 0.0917 (Talos) + 0.1333 (BitGo)
+        weight: 2_6950
       - beneficiary: "GSF-SVRewards-1::12201725270d497ab23ceffd0d2acce46cc9da44586fd494786ef53cc58b6e4abd79"
         weight: 10_0000
       - beneficiary: "validator_Broadridge::1220b0008ea5531b9e47d3315a822ca8b923b5bdd568c934557402d7160b8af4815d"
@@ -65,10 +65,8 @@ approvedSvIdentities:
         weight: 3_0000
       - beneficiary: "Taurus-ghost-1::1220f5cf298f609f538b46a2a0347d299028ddca7ea008aaed65e0ca862db974c5e2" # Taurus CIP-0077 # escrow party_id added to the GhostSV-validator-1
         weight: 2_0000
-      - beneficiary: "fb-linkprd-1::1220f36cae436fcf2c40f31656cdc0ffe8b3db5047b6f2da1f87435393efa2bcd263" # Fireblocks CIP-0072 # active party_id used to receive an earned weight for completed milestone(s)
-        weight: 2_0800
-      - beneficiary: "Fireblocks-ghost-1::1220f5cf298f609f538b46a2a0347d299028ddca7ea008aaed65e0ca862db974c5e2" # Fireblocks CIP-0072 # escrow party_id added to the GhostSV-validator-1
-        weight: 2_0000
+      - beneficiary: "fb-linkprd-1::1220f36cae436fcf2c40f31656cdc0ffe8b3db5047b6f2da1f87435393efa2bcd263" # Fireblocks CIP-0072
+        weight: 2_5800
       - beneficiary: "Bitgo-mainnetValidator-1::1220339ffe631ef7d0296d957d467186b6693e89b8fa654e9acfaa2b4f53437310ff" # BitGo CIP-0074 # active party_id used to receive an earned weight for completed milestone(s)
         weight: 2_8667
       - beneficiary: "BitGo-ghost-1::1220f5cf298f609f538b46a2a0347d299028ddca7ea008aaed65e0ca862db974c5e2" # BitGo CIP-0074 # escrow party_id added to the GhostSV-validator-1

--- a/configs/TestNet/approved-sv-id-values.yaml
+++ b/configs/TestNet/approved-sv-id-values.yaml
@@ -18,8 +18,8 @@ approvedSvIdentities:
     publicKey: MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETri1wBeoV3AYnEF/slvViz9GO2g2lcxUQ3SadBTA70Kn87KzAZ/25n6+hhuRebuuGlm70KFKGJGr8RFd1YjB1Q==
     rewardWeightBps: 188_1000
     extraBeneficiaries:
-      - beneficiary: "GhostSV-validator-1::1220d1c3265d2d5e43ddb1dda4fbb42a1b3780c94ebd86c5aac178845fc9ddec90ef" # All weight not assigned to any particular SV is added to the GhostSV-validator-1; 0.05 (Ubyx) + 0.92 (Fireblocks) + 0.0917 (Talos) + 0.1333 (BitGo)
-        weight: 1_1950
+      - beneficiary: "GhostSV-validator-1::1220d1c3265d2d5e43ddb1dda4fbb42a1b3780c94ebd86c5aac178845fc9ddec90ef" # All weight not assigned to any particular SV is added to the GhostSV-validator-1; 0.05 (Ubyx) + 2.42 (Fireblocks) + 0.0917 (Talos) + 0.1333 (BitGo)
+        weight: 2_6950
       - beneficiary: "GSF-SVRewards-1::1220224995ee62e3176d395b1ae1fd95af8132b1da754e20af24e1c73074d936dced"
         weight: 10_0000
       - beneficiary: "thetie-validator-0::1220eba2eab5c94c78de4a64f600c9eab445af50f59e20bca8f555abbd53748d5223" # The Tie
@@ -64,10 +64,8 @@ approvedSvIdentities:
         weight: 3_0000
       - beneficiary: "Taurus-ghost-1::1220d1c3265d2d5e43ddb1dda4fbb42a1b3780c94ebd86c5aac178845fc9ddec90ef" # Taurus CIP-0077 # escrow party_id added to the GhostSV-validator-1
         weight: 2_0000
-      - beneficiary: "Fireblocks-ghost-1::1220d1c3265d2d5e43ddb1dda4fbb42a1b3780c94ebd86c5aac178845fc9ddec90ef" # Fireblocks CIP-0072 # active party_id used to receive an earned weight for completed milestone(s)
-        weight: 2_0800
-      - beneficiary: "Fireblocks-ghost-1::1220d1c3265d2d5e43ddb1dda4fbb42a1b3780c94ebd86c5aac178845fc9ddec90ef" # Fireblocks CIP-0072 # escrow party_id added to the GhostSV-validator-1
-        weight: 2_0000
+      - beneficiary: "Fireblocks-ghost-1::1220d1c3265d2d5e43ddb1dda4fbb42a1b3780c94ebd86c5aac178845fc9ddec90ef" # Fireblocks CIP-0072
+        weight: 2_5800
       - beneficiary: "BitGo-ghost-1::1220d1c3265d2d5e43ddb1dda4fbb42a1b3780c94ebd86c5aac178845fc9ddec90ef" # BitGo CIP-0074 # active party_id used to receive an earned weight for completed milestone(s)
         weight: 2_8667
       - beneficiary: "BitGo-ghost-1::1220d1c3265d2d5e43ddb1dda4fbb42a1b3780c94ebd86c5aac178845fc9ddec90ef" # BitGo CIP-0074 # escrow party_id added to the GhostSV-validator-1


### PR DESCRIPTION
Following the recent [announcement](https://lists.sync.global/g/tokenomics-announce/message/344), Fireblocks has successfully achieved a new milestone - [Adoption Bonus](https://github.com/global-synchronizer-foundation/cips/blob/main/cip-0072/cip-0072.md#deliverables-for-full-sv-reward)

Effective June 12, 2026, at 00:40 UTC, GSF has increased the Fireblocks weight by 0.5, bringing its total minting weight to 2.58.
The 1.5 weight for the "Adoption Bonus" milestone is also removed from the ghost, but does not go anywhere, and those rewards remain unclaimed.

Since the full weight has now been allocated, the temporary escrow party ID has been removed from the `extraBeneficiaries` configuration and replaced with the verified party ID.